### PR TITLE
Add busykube versions subcommand

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -25,7 +25,7 @@ var installCmd = &cobra.Command{
         // Iterate over all subcommands
         for _, subCmd := range RootCmd.Commands() {
 			// Skip specific subcommands
-			if subCmd.Name() == "install" || subCmd.Name() == "help" || subCmd.Name() == "completion" {
+			if subCmd.Name() == "install" || subCmd.Name() == "help" || subCmd.Name() == "completion" || subCmd.Name() == "versions" {
 				continue
 			}
             symlinkPath := filepath.Join(binaryDir, subCmd.Name())

--- a/cmd/versions.go
+++ b/cmd/versions.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+    "debug/buildinfo"
+    "fmt"
+    "os"
+
+    "github.com/spf13/cobra"
+)
+
+// versionsCmd represents the versions command
+var versionsCmd = &cobra.Command{
+    Use:   "versions",
+    Short: "Print versions of kubectl, kind, and helm",
+    Run: func(cmd *cobra.Command, args []string) {
+        printVersions()
+    },
+}
+
+func init() {
+    RootCmd.AddCommand(versionsCmd)
+}
+
+func printVersions() {
+    // Open the current executable
+    exe, err := os.Executable()
+    if err != nil {
+        fmt.Printf("Error getting executable: %v\n", err)
+        return
+    }
+
+    // Read build information from the executable
+    info, err := buildinfo.ReadFile(exe)
+    if err != nil {
+        fmt.Printf("Error reading build info: %v\n", err)
+        return
+    }
+
+    // Define the modules to look for
+    modules := map[string]string{
+        "kubectl": "k8s.io/client-go",
+        "kind":    "sigs.k8s.io/kind",
+        "helm":    "helm.sh/helm/v3",
+    }
+
+    // Find and print the versions
+    for name, path := range modules {
+        version := findModuleVersion(info, path)
+        if version != "" {
+            fmt.Printf("%s: %s\n", name, version)
+        } else {
+            fmt.Printf("%s: unknown\n", name)
+        }
+    }
+}
+
+func findModuleVersion(info *buildinfo.BuildInfo, modulePath string) string {
+    for _, dep := range info.Deps {
+        if dep.Path == modulePath {
+            return dep.Version
+        }
+    }
+    return ""
+}


### PR DESCRIPTION
Show the versions of the various tools bundled in `busykube`.

```console
$ busykube versions                          
kubectl: v0.32.3
kind: v0.27.0
helm: unknown
```